### PR TITLE
adding templating for service commands

### DIFF
--- a/argyle/__init__.py
+++ b/argyle/__init__.py
@@ -2,6 +2,7 @@
 Argyle is a collection of Fabric utilities for Django deployment.
 """
 
+
 __version_info__ = {
     'major': 0,
     'minor': 1,
@@ -14,7 +15,7 @@ def get_version():
     Return the formatted version information
     """
     vers = ["%(major)i.%(minor)i" % __version_info__, ]
-    
+
     if __version_info__['micro']:
         vers.append(".%(micro)i" % __version_info__)
     if __version_info__['releaselevel'] != 'final':

--- a/argyle/system.py
+++ b/argyle/system.py
@@ -1,4 +1,5 @@
-from fabric.api import put, sudo, task
+import argyle
+from fabric.api import put, sudo, task, env
 
 
 @task
@@ -58,7 +59,10 @@ def create_user(name, groups=None, key_file=None):
 def service_command(name, command):
     """Run an init.d command."""
 
-    sudo(u"/etc/init.d/%s %s" % (name, command)) 
+    service_command_template = getattr(env, 'ARGYLE_SERVICE_COMMAND_TEMPLATE',
+                                       u'/etc/init.d/%(name)s %(command)s')
+    sudo(env.service_command_template % {'name': name,
+                                         'command': command})
 
 
 @task


### PR DESCRIPTION
This allows people on other operating systems to use the service commands as well by customizing the env.service_command_template.

For example, Arch Linux keeps all services in `/etc/rc.d/` and in recent times, using the`rc.d` command is favored over calling the scripts from the services directory. Simply changing `service_command` to use `invoke-rc.d` wouldn't have been enough because it has different argument order.

```
invoke-rc.d nginx restart
```

vs

```
rc.d restart nginx
```

What I've done solves the problem of specifying the dir, or service script in the most general way possible. Allowing most any distro I know of to us this.

I did no add documentation for this as not much else is documented yet, so I'd be shooting in the dark by trying to add it.
